### PR TITLE
deploy new contribution contract and forward calls to it

### DIFF
--- a/contracts/onlydust/marketplace/core/contributions/access_control.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/access_control.cairo
@@ -107,10 +107,10 @@ namespace access_control {
         alloc_locals;
 
         let (caller_address) = get_caller_address();
-        let (is_lead_contributor) = internal.is_lead_contributor(project_id, caller_address);
+        let (is_lead) = is_lead_contributor(project_id, caller_address);
 
         with_attr error_message("Contributions: LEAD_CONTRIBUTOR role required") {
-            assert_not_zero(is_lead_contributor);
+            assert_not_zero(is_lead);
         }
 
         return ();
@@ -142,21 +142,13 @@ namespace access_control {
         alloc_locals;
 
         let (caller_address) = get_caller_address();
-        let (is_project_member) = internal.is_project_member(project_id, caller_address);
-        let (is_lead_contributor) = internal.is_lead_contributor(project_id, caller_address);
+        let (is_member) = is_project_member(project_id, caller_address);
+        let (is_lead) = is_lead_contributor(project_id, caller_address);
 
         with_attr error_message("Contributions: PROJECT_MEMBER or LEAD_CONTRIBUTOR role required") {
-            assert_not_zero(is_project_member + is_lead_contributor);
+            assert_not_zero(is_member + is_lead);
         }
 
-        return ();
-    }
-}
-
-namespace internal {
-    func assert_not_caller{syscall_ptr: felt*}(address: felt) {
-        let (caller_address) = get_caller_address();
-        assert_not_zero(caller_address - address);
         return ();
     }
 
@@ -176,5 +168,13 @@ namespace internal {
             Role.PROJECT_MEMBER, project_id, account
         );
         return (is_project_member,);
+    }
+}
+
+namespace internal {
+    func assert_not_caller{syscall_ptr: felt*}(address: felt) {
+        let (caller_address) = get_caller_address();
+        assert_not_zero(caller_address - address);
+        return ();
     }
 }

--- a/contracts/onlydust/marketplace/core/contributions/contributions.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/contributions.cairo
@@ -45,10 +45,11 @@ func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 //
 
 @view
-func past_contributions{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    contributor_id: Uint256
-) -> (num_contributions: felt) {
-    return contributions.past_contributions(contributor_id);
+func past_contribution_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contributor_account
+) -> (count: felt) {
+    let count = contributions.past_contributions_count(contributor_account);
+    return (count,);
 }
 
 //

--- a/contracts/onlydust/marketplace/core/contributions/contributions.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/contributions.cairo
@@ -23,17 +23,6 @@ from onlydust.marketplace.library.migration_library import (
 )
 
 //
-// STORAGE
-//
-@storage_var
-func contributions_deploy_salt_() -> (salt: felt) {
-}
-
-@event
-func ContributionDeployed(contract_address) {
-}
-
-//
 // Constructor
 //
 @constructor
@@ -85,22 +74,7 @@ func revoke_admin_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 func new_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     project_id: felt, issue_number: felt, gate: felt
 ) -> (contribution: Contribution) {
-    const GITHUB_CONTRIBUTION_CLASS_HASH = 0x0;
-    let (this) = get_contract_address();
-    let (current_salt) = contributions_deploy_salt_.read();
-
-    let (contract_address) = deploy(
-        class_hash=GITHUB_CONTRIBUTION_CLASS_HASH,
-        contract_address_salt=current_salt,
-        constructor_calldata_size=5,
-        constructor_calldata=cast(new (this, this, project_id, issue_number, gate,), felt*),
-        deploy_from_zero=FALSE,
-    );
-    salt.write(value=current_salt + 1);
-
-    ContributionDeployed.emit(contract_address);
-
-    return Contribution(project_id, issue_number, gate);
+    return contributions.deploy_new_contribution(project_id, issue_number, gate);
 }
 
 @external
@@ -171,4 +145,18 @@ func remove_member_for_project{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, r
     project_id: felt, contributor_account: felt
 ) {
     return contributions.remove_member_for_project(project_id, contributor_account);
+}
+
+@view
+func is_lead_contributor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contributor_account
+) -> (res: felt) {
+    return contributions.is_lead_contributor(contributor_account);
+}
+
+@view
+func is_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contributor_account
+) -> (res: felt) {
+    return contributions.is_member(contributor_account);
 }

--- a/contracts/onlydust/marketplace/core/contributions/contributions_migration.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/contributions_migration.cairo
@@ -1,0 +1,116 @@
+%lang starknet
+//
+//
+// Code not compiled and not used
+// Preparation work for https://www.notion.so/onlydust/Clean-up-contributor_id-from-codebase-e54f6214552e4604bad9d67c08778800
+// Migrate the past_contributions_count(contributor_id) => past_contributions_count(contributor_account) for all legacy ids
+//
+//
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero
+from starkware.cairo.common.uint256 import Uint256, uint256_add, split_64
+from starkware.cairo.common.math_cmp import is_le, is_not_zero, is_nn
+from starkware.cairo.common.alloc import alloc
+from starkware.starknet.common.syscalls import get_contract_address
+
+from onlydust.stream.default_implementation import stream
+
+const STAGING_CONTRIBUTIONS_CONTRACT = 0x04aa3b2b258388a58ed429795ab56a9cd9613152755ec317f5c6bee2294e2264;
+const STAGING_PROFILE_CONTRACT = 0x02c14d6aa7db2bac800fcfa3217e98d340351da192531f3f7839b89a4af7e8a7;
+const STAGING_CONTRIBUTORS_COUNT = 8;
+
+const PROD_CONTRIBUTIONS_CONTRACT = 0x011d60f34d8e7b674833d86aa85afbe234baad95ae6ca3d9cb5c4bcd164b7358;
+const PROD_PROFILE_CONTRACT = 0x004176872b71583cb9bc3671db28f26e7f426a7c0764613a0838bb99ef373aa6;
+const PROD_CONTRIBUTORS_COUNT = 0x10d;
+
+@storage_var
+func past_contributions_(contributor_id: Uint256) -> (contribution_count: felt) {
+}
+
+@contract_interface
+namespace IProfile {
+    func ownerOf(tokenId: Uint256) -> (owner: felt) {
+    }
+}
+
+@external
+func migrate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let count = contributors_count();
+    loop(count, Uint256(0, 0));
+    return ();
+}
+
+func loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    remaining_count: felt, contributor_id: Uint256
+) {
+    if (remaining_count == 0) {
+        return ();
+    }
+    migrate_past_contributions_count(contributor_id);
+
+    let (next_contributor_id: Uint256, _: felt) = uint256_add(contributor_id, Uint256(1, 0));
+
+    loop(remaining_count - 1, next_contributor_id);
+    return ();
+}
+
+func migrate_past_contributions_count{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(contributor_id: Uint256) {
+    let profile = profile_contract();
+    let (contributor_account) = IProfile.ownerOf(profile, contributor_id);
+    let (count) = past_contributions_.read(contributor_id);
+    past_contributions_.write(Uint256(contributor_account, 0), count);
+    return ();
+}
+
+func is_production{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+    let (this) = get_contract_address();
+    if (this == PROD_CONTRIBUTIONS_CONTRACT) {
+        return 1;
+    }
+
+    return 0;
+}
+
+func is_staging{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+    let (this) = get_contract_address();
+    if (this == STAGING_CONTRIBUTIONS_CONTRACT) {
+        return 1;
+    }
+
+    return 0;
+}
+
+func profile_contract{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+    if (is_production() == 1) {
+        return PROD_PROFILE_CONTRACT;
+    }
+
+    if (is_staging() == 1) {
+        return STAGING_PROFILE_CONTRACT;
+    }
+
+    with_attr error_message("Neither in prod nor staging") {
+        assert 1 = 0;
+    }
+
+    return 0;
+}
+
+func contributors_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+    if (is_production() == 1) {
+        return PROD_CONTRIBUTORS_COUNT;
+    }
+
+    if (is_staging() == 1) {
+        return STAGING_CONTRIBUTORS_COUNT;
+    }
+
+    with_attr error_message("Neither in prod nor staging") {
+        assert 1 = 0;
+    }
+
+    return 0;
+}

--- a/contracts/onlydust/marketplace/core/contributions/library.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/library.cairo
@@ -284,11 +284,11 @@ namespace contributions {
     //
 
     // Get the number of past contributions for a given contributor
-    func past_contributions{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        contributor_id: Uint256
-    ) -> (num_contributions: felt) {
-        let (num_contributions) = past_contributions_.read(contributor_id);
-        return (num_contributions,);
+    func past_contributions_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        contributor_account
+    ) -> felt {
+        let (count: felt) = past_contributions_.read(Uint256(contributor_account, 0));
+        return count;
     }
 
     func add_lead_contributor_for_project{

--- a/contracts/onlydust/marketplace/core/contributions/library.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/library.cairo
@@ -7,7 +7,13 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.math import assert_nn, assert_lt, assert_le, assert_not_zero, sign
 from starkware.cairo.common.math_cmp import is_not_zero, is_le
 from starkware.cairo.common.hash import hash2
-from starkware.starknet.common.syscalls import get_caller_address, get_contract_address, deploy
+from starkware.starknet.common.syscalls import (
+    get_caller_address,
+    get_contract_address,
+    deploy,
+    get_tx_info,
+    TxInfo,
+)
 
 from onlydust.stream.default_implementation import stream
 from onlydust.marketplace.core.contributions.access_control import (
@@ -363,7 +369,7 @@ namespace contributions {
         let contribution_exists = contribution_access.exists(contribution_id);
         if (contribution_exists == 0) {
             let contract_address = contribution_id.inner;
-            let (contributor_account) = get_caller_address();
+            let contributor_account = internal.get_account_caller_address();
             contribution_contributor_.write(contribution_id, contributor_id);
             IContribution.assign(contract_address, contributor_account);
             return ();
@@ -667,5 +673,12 @@ namespace internal {
         contribution_contributor_.write(contribution_id, contributor_id);
 
         return ();
+    }
+
+    func get_account_caller_address{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+    }() -> felt {
+        let (tx_info: TxInfo*) = get_tx_info();
+        return tx_info.account_contract_address;
     }
 }

--- a/contracts/onlydust/marketplace/core/contributions/library.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/library.cairo
@@ -136,6 +136,7 @@ namespace contributions {
     // Write
     //
 
+    // DEPRECATED - only used in unit tests to validate legacy way of creating contributions
     // Add a contribution for a given token id
     func new_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
         project_id: felt, issue_number: felt, gate: felt

--- a/contracts/onlydust/marketplace/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/test_contributions.cairo
@@ -270,7 +270,8 @@ func test_can_assign_gated_contribution_eligible_contributor{
 
     let contribution_id = ContributionId(1);
     let gated_contribution_id = ContributionId(2);
-    let contributor_id = Uint256(1, 0);
+    let contributor_account = 1;
+    let contributor_id = Uint256(contributor_account, 0);
 
     %{ stop_prank = start_prank(ids.LEAD_CONTRIBUTOR_ACCOUNT) %}
     // Create a non-gated contribution
@@ -288,8 +289,7 @@ func test_can_assign_gated_contribution_eligible_contributor{
     contributions.validate_contribution(gated_contribution_id);
     %{ stop_prank() %}
 
-    let (past_contributions) = contributions.past_contributions(contributor_id);
-    assert 2 = past_contributions;
+    assert 2 = contributions.past_contributions_count(contributor_account);
 
     return ();
 }
@@ -552,11 +552,10 @@ func test_anyone_can_get_past_contributions_count{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }() {
     fixture.initialize();
-    let contributor_id = Uint256('greg', '@onlydust');
-    fixture.validate_two_contributions(contributor_id);
+    let contributor_account = 'greg';
+    fixture.validate_two_contributions(Uint256(contributor_account, 0));
 
-    let (past_contribution_count) = contributions.past_contributions(contributor_id);
-    assert 2 = past_contribution_count;
+    assert 2 = contributions.past_contributions_count(contributor_account);
 
     return ();
 }
@@ -717,7 +716,8 @@ func test_can_claim_gated_contribution_as_eligible_contributor{
 
     let contribution_id = ContributionId(1);
     let gated_contribution_id = ContributionId(2);
-    let contributor_id = Uint256(1, 0);
+    let contributor_account = 1;
+    let contributor_id = Uint256(contributor_account, 0);
 
     %{ stop_prank = start_prank(ids.LEAD_CONTRIBUTOR_ACCOUNT) %}
     // Create a non-gated contribution
@@ -731,8 +731,7 @@ func test_can_claim_gated_contribution_as_eligible_contributor{
     contributions.validate_contribution(contribution_id);
     %{ stop_prank() %}
 
-    let (past_contributions) = contributions.past_contributions(contributor_id);
-    assert 1 = past_contributions;
+    assert 1 = contributions.past_contributions_count(contributor_account);
 
     %{ stop_prank = start_prank(ids.PROJECT_MEMBER_ACCOUNT) %}
     // Claim the gated contribution
@@ -782,8 +781,8 @@ namespace fixture {
         contributions.validate_contribution(gated_contribution_id);
         %{ stop_prank() %}
 
-        let (past_contributions) = contributions.past_contributions(contributor_id);
-        assert 2 = past_contributions;
+        let contributor_account = contributor_id.low;
+        assert 2 = contributions.past_contributions_count(contributor_account);
 
         return ();
     }

--- a/contracts/onlydust/marketplace/core/contributions/test_contributions.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/test_contributions.cairo
@@ -217,7 +217,7 @@ func test_cannot_assign_non_existent_contribution{
 
     %{
         stop_prank = start_prank(ids.LEAD_CONTRIBUTOR_ACCOUNT) 
-        expect_revert(error_message="Contributions: Contribution does not exist")
+        expect_revert()
     %}
     contributions.assign_contributor_to_contribution(contribution_id, contributor_id);
     %{ stop_prank() %}
@@ -396,7 +396,7 @@ func test_cannot_unassign_from_non_existent_contribution{
 
     %{
         stop_prank = start_prank(ids.LEAD_CONTRIBUTOR_ACCOUNT) 
-        expect_revert(error_message="Contributions: Contribution does not exist")
+        expect_revert()
     %}
     contributions.unassign_contributor_from_contribution(contribution_id);
     %{ stop_prank() %}
@@ -478,7 +478,7 @@ func test_cannot_validate_non_existent_contribution{
 
     %{
         stop_prank = start_prank(ids.LEAD_CONTRIBUTOR_ACCOUNT) 
-        expect_revert(error_message="Contributions: Contribution does not exist")
+        expect_revert()
     %}
     contributions.validate_contribution(contribution_id);
     %{ stop_prank() %}
@@ -657,7 +657,7 @@ func test_cannot_claim_non_existent_contribution{
 
     %{
         stop_prank = start_prank(ids.PROJECT_MEMBER_ACCOUNT) 
-        expect_revert(error_message="Contributions: Contribution does not exist")
+        expect_revert()
     %}
     contributions.claim_contribution(contribution_id, contributor_id);
     %{ stop_prank() %}

--- a/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
@@ -1,0 +1,170 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from onlydust.marketplace.test.libraries.contributions import assert_contribution_that
+from onlydust.marketplace.core.contributions.library import Contribution, ContributionId
+from onlydust.marketplace.interfaces.contributor_oracle import IContributorOracle
+
+//
+// INTERFACES
+//
+@contract_interface
+namespace IContributions {
+    func new_contribution(project_id: felt, issue_number: felt, gate: felt) -> (
+        contribution: Contribution
+    ) {
+    }
+
+    func delete_contribution(contribution_id: ContributionId) {
+    }
+
+    func assign_contributor_to_contribution(
+        contribution_id: ContributionId, contributor_id: Uint256
+    ) {
+    }
+
+    func unassign_contributor_from_contribution(contribution_id: ContributionId) {
+    }
+
+    func claim_contribution(contribution_id: ContributionId, contributor_id: Uint256) {
+    }
+
+    func validate_contribution(contribution_id: ContributionId) {
+    }
+
+    func modify_gate(contribution_id: ContributionId, gate: felt) {
+    }
+
+    func add_lead_contributor_for_project(project_id: felt, lead_contributor_account: felt) {
+    }
+
+    func remove_lead_contributor_for_project(project_id: felt, lead_contributor_account: felt) {
+    }
+
+    func add_member_for_project(project_id: felt, contributor_account: felt) {
+    }
+
+    func remove_member_for_project(project_id: felt, contributor_account: felt) {
+    }
+}
+
+//
+// CONSTANTS
+//
+const ADMIN = 'admin';
+const CALLER_ACCOUNT = 0;
+const PROJECT_ID = 'starkonquest';
+const CONTRIBUTOR_ACCOUNT = 'greg';
+
+//
+// Tests
+//
+@view
+func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    tempvar contributions_contract;
+    %{
+        print('declaring github contribution')
+        contribution_class_hash = declare("./contracts/onlydust/marketplace/core/github/contribution.cairo", config={"wait_for_acceptance": True}).class_hash
+        print(f'declared github contribution: {hex(contribution_class_hash)}')
+        print('deploying contributions')
+        declared_contributions = declare("./contracts/onlydust/marketplace/core/contributions/contributions.cairo", config={"wait_for_acceptance": True})
+        print(f'declared contributions: {hex(declared_contributions.class_hash)}')
+        prepared_contributions = prepare(declared_contributions, [ids.ADMIN])
+        deployed_contributions = deploy(prepared_contributions)
+        context.contributions_contract = deployed_contributions.contract_address
+        print(f'deployed contract: {hex(context.contributions_contract)}')
+        ids.contributions_contract = context.contributions_contract
+    %}
+    return ();
+}
+
+func set_caller_as_lead_contributor{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
+    let (contributions_contract) = contributions_access.deployed();
+    %{ stop_prank = start_prank(ids.ADMIN, ids.contributions_contract) %}
+    IContributions.add_lead_contributor_for_project(
+        contributions_contract, PROJECT_ID, CALLER_ACCOUNT
+    );
+    %{ stop_prank() %}
+    return ();
+}
+
+func set_caller_as_project_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ) {
+    let (contributions_contract) = contributions_access.deployed();
+    %{ stop_prank = start_prank(ids.ADMIN, ids.contributions_contract) %}
+    IContributions.add_member_for_project(contributions_contract, PROJECT_ID, CALLER_ACCOUNT);
+    %{ stop_prank() %}
+    return ();
+}
+
+@view
+func test_contribution_lifetime_with_legacy_api{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() {
+    alloc_locals;
+
+    let (local contributions_contract) = contributions_access.deployed();
+
+    set_caller_as_lead_contributor();
+
+    let (contribution1: Contribution) = IContributions.new_contribution(
+        contributions_contract, PROJECT_ID, 235, 0
+    );
+    let (contribution2: Contribution) = IContributions.new_contribution(
+        contributions_contract, PROJECT_ID, 236, 2
+    );
+
+    let contribution_id = contribution1.id;
+    IContributions.assign_contributor_to_contribution(
+        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+    );
+    IContributions.unassign_contributor_from_contribution(contributions_contract, contribution_id);
+    IContributions.assign_contributor_to_contribution(
+        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+    );
+    IContributions.validate_contribution(contributions_contract, contribution_id);
+
+    let (count) = IContributorOracle.past_contribution_count(
+        contributions_contract, CONTRIBUTOR_ACCOUNT
+    );
+    assert count = 1;
+
+    let contribution_id = contribution2.id;
+    IContributions.modify_gate(contributions_contract, contribution_id, 1);
+    IContributions.assign_contributor_to_contribution(
+        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+    );
+    IContributions.unassign_contributor_from_contribution(contributions_contract, contribution_id);
+    IContributions.delete_contribution(contributions_contract, contribution_id);
+
+    %{
+        expect_events(
+               {"name": "ContributionCreated", "data": {"contribution_id": ids.contribution1.id.inner, "project_id": ids.PROJECT_ID,  "issue_number": 235, "gate": 0}},
+               {"name": "ContributionCreated", "data": {"contribution_id": ids.contribution2.id.inner, "project_id": ids.PROJECT_ID,  "issue_number": 236, "gate": 2}},
+               {"name": "ContributionAssigned", "data": {"contribution_id": ids.contribution1.id.inner, "contributor_id": {"low": ids.CONTRIBUTOR_ACCOUNT, "high": 0}}},
+               {"name": "ContributionUnassigned", "data": {"contribution_id": ids.contribution1.id.inner}},
+               {"name": "ContributionAssigned", "data": {"contribution_id": ids.contribution1.id.inner, "contributor_id": {"low": ids.CONTRIBUTOR_ACCOUNT, "high": 0}}},
+               {"name": "ContributionValidated", "data": {"contribution_id": ids.contribution1.id.inner}},
+               {"name": "ContributionGateChanged", "data": {"contribution_id": ids.contribution2.id.inner, "gate": 1}},
+               {"name": "ContributionAssigned", "data": {"contribution_id": ids.contribution2.id.inner, "contributor_id": {"low": ids.CONTRIBUTOR_ACCOUNT, "high": 0}}},
+               {"name": "ContributionUnassigned", "data": {"contribution_id": ids.contribution2.id.inner}},
+               {"name": "ContributionDeleted", "data": {"contribution_id": ids.contribution2.id.inner}},
+           )
+    %}
+    return ();
+}
+
+//
+// Libraries
+//
+namespace contributions_access {
+    func deployed() -> (address: felt) {
+        tempvar contributions_contract;
+        %{ ids.contributions_contract = context.contributions_contract %}
+        return (contributions_contract,);
+    }
+}

--- a/contracts/onlydust/marketplace/core/github/contribution.cairo
+++ b/contracts/onlydust/marketplace/core/github/contribution.cairo
@@ -34,11 +34,11 @@ func ContributionAssigned(contribution_id: felt, contributor_id: Uint256) {
 }
 
 @event
-func ContributionUnassigned(contribution_id: felt) {
+func ContributionClaimed(contribution_id: felt, contributor_id: Uint256) {
 }
 
 @event
-func ContributionClaimed(contribution_id: felt, contributor_id: Uint256) {
+func ContributionUnassigned(contribution_id: felt) {
 }
 
 @event
@@ -122,8 +122,12 @@ func assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
 
     // Emit event
     let (contribution_address) = get_contract_address();
+    let (caller) = get_caller_address();
+    if (contributor_account == caller) {
+        ContributionClaimed.emit(contribution_address, Uint256(contributor_account, 0));
+        return ();
+    }
     ContributionAssigned.emit(contribution_address, Uint256(contributor_account, 0));
-
     return ();
 }
 

--- a/contracts/onlydust/marketplace/core/github/contribution.cairo
+++ b/contracts/onlydust/marketplace/core/github/contribution.cairo
@@ -168,6 +168,7 @@ func validate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     return ();
 }
 
+@external
 func modify_gate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(gate: felt) {
     access_control.only_lead_contributor();
     status_access.only_open();
@@ -182,6 +183,7 @@ func modify_gate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     return ();
 }
 
+@external
 func delete{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
     access_control.only_lead_contributor();
     status_access.only_open();

--- a/contracts/onlydust/marketplace/core/github/contribution.cairo
+++ b/contracts/onlydust/marketplace/core/github/contribution.cairo
@@ -79,7 +79,14 @@ func contribution_gate_() -> (gate: felt) {
 //
 // Init
 //
-@external
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contributor_oracle: felt, project_contract: felt, repo_id: felt, issue_number: felt, gate: felt
+) {
+    initialize(contributor_oracle, project_contract, repo_id, issue_number, gate);
+    return ();
+}
+
 func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     contributor_oracle: felt, project_contract: felt, repo_id: felt, issue_number: felt, gate: felt
 ) {

--- a/contracts/onlydust/marketplace/core/github/test_contribution.cairo
+++ b/contracts/onlydust/marketplace/core/github/test_contribution.cairo
@@ -102,7 +102,7 @@ func test_claim{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}
     alloc_locals;
     fixture.init();
 
-    let contributor_account = 42;
+    let contributor_account = 0;  // must be 0 as `start_prank` does not change get_tx_info() result
 
     %{
         stop_mock_oracle = mock_call(ids.ORACLE, "past_contribution_count", [3])

--- a/contracts/onlydust/marketplace/core/github/test_contribution.cairo
+++ b/contracts/onlydust/marketplace/core/github/test_contribution.cairo
@@ -121,7 +121,7 @@ func test_claim{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}
     let (contract_address) = get_contract_address();
     %{
         expect_events(
-               {"name": "ContributionAssigned", "data": {"contribution_id": ids.contract_address, "contributor_id": {"low": ids.contributor_account, "high": 0}}},
+               {"name": "ContributionClaimed", "data": {"contribution_id": ids.contract_address, "contributor_id": {"low": ids.contributor_account, "high": 0}}},
            )
     %}
     return ();

--- a/protostar.toml
+++ b/protostar.toml
@@ -32,4 +32,4 @@ contributions = [
     "./contracts/onlydust/marketplace/core/contributions/contributions.cairo",
 ]
 proxy = ["./lib/cairo_contracts/src/openzeppelin/upgrades/presets/Proxy.cairo"]
-contribution = ["./contracts/onlydust/marketplace/core/github/contribution.cairo"]
+github_contribution = ["./contracts/onlydust/marketplace/core/github/contribution.cairo"]


### PR DESCRIPTION
- ♻️ implement ContributorOracle by Contributions contract
- 🚧 prepare storage migration for contributor_id removal
- ✨ deploy new contribution contract upon new_contribution call
- ✨ forward calls to new contribution contract when applicable
- ♻️ use tx_info to get account caller address to allow access control when calling from legaxy contract
- ✅ add e2e test with legacy api
- ✅ add e2e test with new API
- ✅ add claim e2e test with legacy api
