### PR TITLE
migrate contributor_id to contributor_account_address in smart contracts

### DIFF
--- a/contracts/onlydust/marketplace/core/contributions/contributions.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/contributions.cairo
@@ -87,15 +87,19 @@ func delete_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_c
 @external
 func assign_contributor_to_contribution{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
-}(contribution_id: ContributionId, contributor_id: Uint256) {
-    return contributions.assign_contributor_to_contribution(contribution_id, contributor_id);
+}(contribution_id: ContributionId, contributor_account_address: felt) {
+    return contributions.assign_contributor_to_contribution(
+        contribution_id, contributor_account_address
+    );
 }
 
 @external
 func unassign_contributor_from_contribution{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
-}(contribution_id: ContributionId) {
-    return contributions.unassign_contributor_from_contribution(contribution_id);
+}(contribution_id: ContributionId, contributor_account_address: felt) {
+    return contributions.unassign_contributor_from_contribution(
+        contribution_id, contributor_account_address
+    );
 }
 
 @external
@@ -107,9 +111,9 @@ func claim_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
 
 @external
 func validate_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    contribution_id: ContributionId
+    contribution_id: ContributionId, contributor_account_address: felt
 ) {
-    return contributions.validate_contribution(contribution_id);
+    return contributions.validate_contribution(contribution_id, contributor_account_address);
 }
 
 @external

--- a/contracts/onlydust/marketplace/core/contributions/contributions_migration.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/contributions_migration.cairo
@@ -60,8 +60,9 @@ func migrate_past_contributions_count{
 }(contributor_id: Uint256) {
     let profile = profile_contract();
     let (contributor_account) = IProfile.ownerOf(profile, contributor_id);
-    let (count) = past_contributions_.read(contributor_id);
-    past_contributions_.write(Uint256(contributor_account, 0), count);
+    let (count_for_id) = past_contributions_.read(contributor_id);  // old_count
+    let (count_for_account) = past_contributions_.read(Uint256(contributor_account, 0));  // new_count (should be 0)
+    past_contributions_.write(Uint256(contributor_account, 0), count_for_id + count_for_account);  // new_count = new_count + old_count
     return ();
 }
 

--- a/contracts/onlydust/marketplace/core/contributions/library.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/library.cairo
@@ -271,19 +271,18 @@ namespace contributions {
     // Assign a contributor to a contribution
     func assign_contributor_to_contribution{
         syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
-    }(contribution_id: ContributionId, contributor_id: Uint256) {
+    }(contribution_id: ContributionId, contributor_account_address: felt) {
         let contribution_exists = contribution_access.exists(contribution_id);
         if (contribution_exists == 0) {
             let contract_address = contribution_id.inner;
-            let contributor_account = contributor_id.low;
-            contribution_contributor_.write(contribution_id, contributor_id);
-            IContribution.assign(contract_address, contributor_account);
+            IContribution.assign(contract_address, contributor_account_address);
             return ();
         }
 
         let (project_id) = project_access.find_contribution_project(contribution_id);
         access_control.only_lead_contributor(project_id);
 
+        let contributor_id = Uint256(contributor_account_address, 0);
         internal.assign_contributor_to_contribution(contribution_id, contributor_id);
 
         // Emit event
@@ -295,14 +294,11 @@ namespace contributions {
     // Unassign a contributor from a contribution
     func unassign_contributor_from_contribution{
         syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
-    }(contribution_id: ContributionId) {
+    }(contribution_id: ContributionId, contributor_account_address: felt) {
         let contribution_exists = contribution_access.exists(contribution_id);
         if (contribution_exists == 0) {
             let contract_address = contribution_id.inner;
-            let (contributor_id) = contribution_contributor_.read(contribution_id);
-            let contributor_account = contributor_id.low;
-            IContribution.unassign(contract_address, contributor_account);
-            contribution_contributor_.write(contribution_id, Uint256(0, 0));
+            IContribution.unassign(contract_address, contributor_account_address);
             return ();
         }
 
@@ -323,20 +319,18 @@ namespace contributions {
 
     // Validate a contribution, marking it as completed
     func validate_contribution{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-        contribution_id: ContributionId
+        contribution_id: ContributionId, contributor_account_address: felt
     ) {
         // Increase contributor contribution_count
         // Must be done before forwarding the call to the new contribution contract
-        let (contributor_id) = contribution_contributor_.read(contribution_id);
+        let contributor_id = Uint256(contributor_account_address, 0);
         let (past_contributions) = past_contributions_.read(contributor_id);
         past_contributions_.write(contributor_id, past_contributions + 1);
 
         let contribution_exists = contribution_access.exists(contribution_id);
         if (contribution_exists == 0) {
             let contract_address = contribution_id.inner;
-            let (contributor_id) = contribution_contributor_.read(contribution_id);
-            let contributor_account = contributor_id.low;
-            IContribution.validate(contract_address, contributor_account);
+            IContribution.validate(contract_address, contributor_account_address);
             return ();
         }
 

--- a/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
@@ -22,17 +22,19 @@ namespace IContributions {
     }
 
     func assign_contributor_to_contribution(
-        contribution_id: ContributionId, contributor_id: Uint256
+        contribution_id: ContributionId, contributor_account_adress: felt
     ) {
     }
 
-    func unassign_contributor_from_contribution(contribution_id: ContributionId) {
+    func unassign_contributor_from_contribution(
+        contribution_id: ContributionId, contributor_account_adress: felt
+    ) {
     }
 
     func claim_contribution(contribution_id: ContributionId, contributor_id: Uint256) {
     }
 
-    func validate_contribution(contribution_id: ContributionId) {
+    func validate_contribution(contribution_id: ContributionId, contributor_account_adress: felt) {
     }
 
     func modify_gate(contribution_id: ContributionId, gate: felt) {
@@ -145,13 +147,17 @@ func test_contribution_lifetime_with_legacy_api{
 
     let contribution_id = contribution1.id;
     IContributions.assign_contributor_to_contribution(
-        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
     );
-    IContributions.unassign_contributor_from_contribution(contributions_contract, contribution_id);
+    IContributions.unassign_contributor_from_contribution(
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
+    );
     IContributions.assign_contributor_to_contribution(
-        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
     );
-    IContributions.validate_contribution(contributions_contract, contribution_id);
+    IContributions.validate_contribution(
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
+    );
 
     let (count) = IContributorOracle.past_contribution_count(
         contributions_contract, CONTRIBUTOR_ACCOUNT
@@ -161,9 +167,11 @@ func test_contribution_lifetime_with_legacy_api{
     let contribution_id = contribution2.id;
     IContributions.modify_gate(contributions_contract, contribution_id, 1);
     IContributions.assign_contributor_to_contribution(
-        contributions_contract, contribution_id, Uint256(CONTRIBUTOR_ACCOUNT, 0)
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
     );
-    IContributions.unassign_contributor_from_contribution(contributions_contract, contribution_id);
+    IContributions.unassign_contributor_from_contribution(
+        contributions_contract, contribution_id, CONTRIBUTOR_ACCOUNT
+    );
     IContributions.delete_contribution(contributions_contract, contribution_id);
 
     %{
@@ -206,7 +214,7 @@ func test_contribution_claimed_with_legacy_api{
 
     set_caller_as_lead_contributor();
 
-    IContributions.validate_contribution(contributions_contract, contribution_id);
+    IContributions.validate_contribution(contributions_contract, contribution_id, CALLER_ACCOUNT);
 
     let (count) = IContributorOracle.past_contribution_count(
         contributions_contract, CALLER_ACCOUNT

--- a/protostar.toml
+++ b/protostar.toml
@@ -31,5 +31,8 @@ target = ["contracts"]
 contributions = [
     "./contracts/onlydust/marketplace/core/contributions/contributions.cairo",
 ]
+contributions_migration = [
+    "./contracts/onlydust/marketplace/core/contributions/contributions_migration.cairo",
+]
 proxy = ["./lib/cairo_contracts/src/openzeppelin/upgrades/presets/Proxy.cairo"]
 github_contribution = ["./contracts/onlydust/marketplace/core/github/contribution.cairo"]


### PR DESCRIPTION
- 🗃️ migrate past contribution count from contributor id to contributor account
- ♻️ use input contributor_account_address to assign and compute past contribution count
