### PR TITLE
create composite assignment strategy

### DIFF
--- a/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
@@ -1,15 +1,19 @@
 %lang starknet
 
 from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.starknet.common.syscalls import library_call
-from openzeppelin.security.Initializable.library import Initializable
 
 //
 // This strategy allows to use several strategies as a single one
 //
 
 // STORAGES
+@storage_var
+func assignment_strategy__composite__initialized() -> (initialized: felt) {
+}
+
 @storage_var
 func assignment_strategy__composite__strategy_count() -> (strategy_count: felt) {
 }
@@ -40,7 +44,12 @@ func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     strategies_len, strategies: felt*
 ) {
-    Initializable.initialize();
+    with_attr error_message("Composite: already initialized") {
+        let (initialized) = assignment_strategy__composite__initialized.read();
+        assert FALSE = initialized;
+        assignment_strategy__composite__initialized.write(TRUE);
+    }
+
     internal.store_strategy_loop(strategies_len, strategies);
     assignment_strategy__composite__strategy_count.write(strategies_len);
 

--- a/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
@@ -1,13 +1,75 @@
 %lang starknet
 
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
 //
 // This strategy allows to use several strategies as a single one
 //
 
-//
-// STRATEGY IMPLEMENTATION
-//
+// STORAGES
+@storage_var
+func assignment_strategy__composite__strategy_count() -> (strategy_count: felt) {
+}
 
+@storage_var
+func assignment_strategy__composite__strategy_hash_by_index(index: felt) -> (strategy_hash: felt) {
+}
+
+//
+// MANAGEMENT FUNCTIONS
+//
 @external
-func initialize(strategies_len, strategies: felt*) {
+func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    strategies_len, strategies: felt*
+) {
+    internal.store_strategy_loop(strategies_len, strategies);
+    assignment_strategy__composite__strategy_count.write(strategies_len);
+
+    return ();
+}
+
+@view
+func strategies{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    strategies_len: felt, strategies: felt*
+) {
+    alloc_locals;
+
+    let (strategies_len) = assignment_strategy__composite__strategy_count.read();
+    let (local strategies) = alloc();
+    internal.read_strategy_loop(strategies_len, strategies);
+
+    return (strategies_len, strategies);
+}
+
+//
+// INTERNAL
+//
+namespace internal {
+    func store_strategy_loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        strategies_len, strategies: felt*
+    ) {
+        if (strategies_len == 0) {
+            return ();
+        }
+
+        assignment_strategy__composite__strategy_hash_by_index.write(strategies_len, [strategies]);
+
+        return store_strategy_loop(strategies_len - 1, strategies + 1);
+    }
+
+    func read_strategy_loop{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        strategies_len, strategies: felt*
+    ) {
+        if (strategies_len == 0) {
+            return ();
+        }
+
+        let (strategy) = assignment_strategy__composite__strategy_hash_by_index.read(
+            strategies_len
+        );
+        assert [strategies] = strategy;
+
+        return read_strategy_loop(strategies_len - 1, strategies + 1);
+    }
 }

--- a/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo
@@ -2,6 +2,7 @@
 
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from openzeppelin.security.Initializable.library import Initializable
 
 //
 // This strategy allows to use several strategies as a single one
@@ -23,6 +24,7 @@ func assignment_strategy__composite__strategy_hash_by_index(index: felt) -> (str
 func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     strategies_len, strategies: felt*
 ) {
+    Initializable.initialize();
     internal.store_strategy_loop(strategies_len, strategies);
     assignment_strategy__composite__strategy_count.write(strategies_len);
 

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -54,6 +54,9 @@ func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
         'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
     );
     register_selector(
+        'on_unassigned', 0x85a2edab325660d13eb75ace9a6737467ded8f85473feb457595808fbbfdce
+    );
+    register_selector(
         'assert_can_validate', 0x335791ca04a8d33572330929a1f5d0ed5ccb04474422093c6ca6cb510ad1bc6
     );
 
@@ -156,6 +159,22 @@ func test_can_unassign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let test_strategy_hash = TestStrategy.declared();
     with test_strategy_hash {
         let count = TestStrategy.get_function_call_count('assert_can_unassign');
+        assert 3 = count;
+    }
+
+    return ();
+}
+
+@view
+func test_on_unassigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let composite_strategy_hash = Composite.default();
+    IAssignmentStrategy.library_call_on_unassigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
+
+    let test_strategy_hash = TestStrategy.declared();
+    with test_strategy_hash {
+        let count = TestStrategy.get_function_call_count('on_unassigned');
         assert 3 = count;
     }
 

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -48,6 +48,19 @@ func test_initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
     return ();
 }
 
+@view
+func test_cannot_initialize_twice{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    ) {
+    %{ expect_revert(error_message="Initializable: contract already initialized") %}
+    let composite_strategy_hash = Composite.declared();
+    with composite_strategy_hash {
+        Composite.initialize(0, new ());
+        Composite.initialize(0, new ());
+    }
+
+    return ();
+}
+
 //
 // Composite functions
 //

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -59,6 +59,9 @@ func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     register_selector(
         'assert_can_validate', 0x335791ca04a8d33572330929a1f5d0ed5ccb04474422093c6ca6cb510ad1bc6
     );
+    register_selector(
+        'on_validated', 0x8a3674db7fb20b307d4be1223ac3ebe7d05225da47a185d1fffacc26f495c7
+    );
 
     return ();
 }
@@ -193,6 +196,22 @@ func test_can_validate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let test_strategy_hash = TestStrategy.declared();
     with test_strategy_hash {
         let count = TestStrategy.get_function_call_count('assert_can_validate');
+        assert 3 = count;
+    }
+
+    return ();
+}
+
+@view
+func test_on_validated{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let composite_strategy_hash = Composite.default();
+    IAssignmentStrategy.library_call_on_validated(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
+
+    let test_strategy_hash = TestStrategy.declared();
+    with test_strategy_hash {
+        let count = TestStrategy.get_function_call_count('on_validated');
         assert 3 = count;
     }
 

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -77,20 +77,14 @@ func test_can_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_assign');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_assign');
 
     return ();
 }
 
 @view
 func test_cannot_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        AssignmentStrategyMock.request_revert();
-    }
+    AssignmentStrategyMock.request_revert();
 
     %{ expect_revert() %}
     let composite_strategy_hash = Composite.default();
@@ -106,10 +100,7 @@ func test_on_assigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_assigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('on_assigned');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('on_assigned');
 
     return ();
 }
@@ -123,10 +114,7 @@ func test_can_unassign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_unassign');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_unassign');
 
     return ();
 }
@@ -138,10 +126,7 @@ func test_on_unassigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_unassigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('on_unassigned');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('on_unassigned');
 
     return ();
 }
@@ -155,10 +140,7 @@ func test_can_validate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_validate');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_validate');
 
     return ();
 }
@@ -170,10 +152,7 @@ func test_on_validated{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_validated(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = AssignmentStrategyMock.declared();
-    with test_strategy_hash {
-        assert 3 = AssignmentStrategyMock.get_function_call_count('on_validated');
-    }
+    assert 3 = AssignmentStrategyMock.get_function_call_count('on_validated');
 
     return ();
 }
@@ -207,7 +186,7 @@ namespace Composite {
     func default{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
         alloc_locals;
 
-        let test_strategy_hash = AssignmentStrategyMock.declared();
+        let test_strategy_hash = AssignmentStrategyMock.class_hash();
         let (local strategies) = alloc();
         assert strategies[0] = test_strategy_hash;
         assert strategies[1] = test_strategy_hash;

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -48,6 +48,9 @@ func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
         'assert_can_assign', 0xafebfa3bc187991e56ad073c19677f894a3a5541d8b8151af100e49077f937
     );
     register_selector(
+        'on_assigned', 0xf897b8b0d9c032035dd00f05036ece8d0323783ada50f77ac038b5ee28a4f7
+    );
+    register_selector(
         'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
     );
     register_selector(
@@ -121,6 +124,22 @@ func test_cannot_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     %{ expect_revert() %}
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.assert_can_assign(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
+
+    return ();
+}
+
+@view
+func test_on_assigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let composite_strategy_hash = Composite.default();
+    IAssignmentStrategy.library_call_on_assigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
+
+    let test_strategy_hash = TestStrategy.declared();
+    with test_strategy_hash {
+        let count = TestStrategy.get_function_call_count('on_assigned');
+        assert 3 = count;
+    }
 
     return ();
 }

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -2,8 +2,8 @@
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
-from starkware.starknet.common.syscalls import get_contract_address
 from onlydust.marketplace.interfaces.assignment_strategy import IAssignmentStrategy
+from onlydust.marketplace.test.libraries.assignment_strategy_mock import AssignmentStrategyMock
 
 //
 // CONSTANTS
@@ -22,47 +22,13 @@ namespace IComposite {
     }
 }
 
-@contract_interface
-namespace ITestStrategy {
-    func request_revert() {
-    }
-}
-
 //
 // TESTS
 //
-func register_selector(function_name, selector) {
-    %{ context.selectors[ids.function_name] = ids.selector %}
-    return ();
-}
-
 @view
 func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    %{
-        context.composite_strategy_hash = declare("./contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo", config={"wait_for_acceptance": True}).class_hash 
-        context.test_strategy_hash = declare("./contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo", config={"wait_for_acceptance": True}).class_hash
-        context.selectors = {}
-    %}
-
-    register_selector(
-        'assert_can_assign', 0xafebfa3bc187991e56ad073c19677f894a3a5541d8b8151af100e49077f937
-    );
-    register_selector(
-        'on_assigned', 0xf897b8b0d9c032035dd00f05036ece8d0323783ada50f77ac038b5ee28a4f7
-    );
-    register_selector(
-        'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
-    );
-    register_selector(
-        'on_unassigned', 0x85a2edab325660d13eb75ace9a6737467ded8f85473feb457595808fbbfdce
-    );
-    register_selector(
-        'assert_can_validate', 0x335791ca04a8d33572330929a1f5d0ed5ccb04474422093c6ca6cb510ad1bc6
-    );
-    register_selector(
-        'on_validated', 0x8a3674db7fb20b307d4be1223ac3ebe7d05225da47a185d1fffacc26f495c7
-    );
-
+    %{ context.composite_strategy_hash = declare("./contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo", config={"wait_for_acceptance": True}).class_hash %}
+    AssignmentStrategyMock.setup();
     return ();
 }
 
@@ -111,10 +77,9 @@ func test_can_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('assert_can_assign');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_assign');
     }
 
     return ();
@@ -122,9 +87,9 @@ func test_can_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
 
 @view
 func test_cannot_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        TestStrategy.request_revert();
+        AssignmentStrategyMock.request_revert();
     }
 
     %{ expect_revert() %}
@@ -141,10 +106,9 @@ func test_on_assigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_assigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('on_assigned');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('on_assigned');
     }
 
     return ();
@@ -159,10 +123,9 @@ func test_can_unassign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('assert_can_unassign');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_unassign');
     }
 
     return ();
@@ -175,10 +138,9 @@ func test_on_unassigned{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_unassigned(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('on_unassigned');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('on_unassigned');
     }
 
     return ();
@@ -193,10 +155,9 @@ func test_can_validate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
         composite_strategy_hash, CONTRIBUTOR_ADDRESS
     );
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('assert_can_validate');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('assert_can_validate');
     }
 
     return ();
@@ -209,10 +170,9 @@ func test_on_validated{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.library_call_on_validated(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
 
-    let test_strategy_hash = TestStrategy.declared();
+    let test_strategy_hash = AssignmentStrategyMock.declared();
     with test_strategy_hash {
-        let count = TestStrategy.get_function_call_count('on_validated');
-        assert 3 = count;
+        assert 3 = AssignmentStrategyMock.get_function_call_count('on_validated');
     }
 
     return ();
@@ -247,7 +207,7 @@ namespace Composite {
     func default{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
         alloc_locals;
 
-        let test_strategy_hash = TestStrategy.declared();
+        let test_strategy_hash = AssignmentStrategyMock.declared();
         let (local strategies) = alloc();
         assert strategies[0] = test_strategy_hash;
         assert strategies[1] = test_strategy_hash;
@@ -259,37 +219,5 @@ namespace Composite {
         }
 
         return composite_strategy_hash;
-    }
-}
-
-//
-// TestStratgegy functions
-//
-namespace TestStrategy {
-    func declared{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
-        tempvar test_strategy_hash;
-        %{ ids.test_strategy_hash = context.test_strategy_hash %}
-        return test_strategy_hash;
-    }
-
-    func request_revert{
-        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
-    }() {
-        ITestStrategy.library_call_request_revert(test_strategy_hash);
-        return ();
-    }
-
-    func get_function_call_count{
-        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
-    }(function_name) -> felt {
-        alloc_locals;
-        tempvar function_call_count;
-        let (local contract_address) = get_contract_address();
-        %{
-            selector = context.selectors[ids.function_name]
-            storage = load(ids.contract_address, "assignment_strategy__test__function_calls", "felt", key=[selector])
-            ids.function_call_count = storage[0]
-        %}
-        return function_call_count;
     }
 }

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -1,0 +1,76 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+
+//
+// INTERFACES
+//
+@contract_interface
+namespace IComposite {
+    func initialize(strategies_len, strategies: felt*) {
+    }
+
+    func strategies() -> (strategies_len: felt, strategies: felt*) {
+    }
+}
+
+//
+// TESTS
+//
+@view
+func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    %{ context.composite_strategy_hash = declare("./contracts/onlydust/marketplace/core/assignment_strategies/composite.cairo", config={"wait_for_acceptance": True}).class_hash %}
+
+    return ();
+}
+
+@view
+func test_initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let (local strategies) = alloc();
+    assert strategies[0] = 0x1111;
+    assert strategies[1] = 0x2222;
+    assert strategies[2] = 0x3333;
+
+    let composite_strategy_hash = Composite.declared();
+    with composite_strategy_hash {
+        Composite.initialize(3, strategies);
+
+        let (strategies_len, strategies) = Composite.strategies();
+        assert 3 = strategies_len;
+        assert 0x1111 = strategies[0];
+        assert 0x2222 = strategies[1];
+        assert 0x3333 = strategies[2];
+    }
+
+    return ();
+}
+
+//
+// Composite functions
+//
+namespace Composite {
+    func declared{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+        tempvar composite_strategy_hash;
+        %{ ids.composite_strategy_hash = context.composite_strategy_hash %}
+        return composite_strategy_hash;
+    }
+
+    func initialize{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, composite_strategy_hash
+    }(strategies_len, strategies: felt*) {
+        IComposite.library_call_initialize(composite_strategy_hash, strategies_len, strategies);
+        return ();
+    }
+
+    func strategies{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, composite_strategy_hash
+    }() -> (strategies_len: felt, strategies: felt*) {
+        let (strategies_len, strategies: felt*) = IComposite.library_call_strategies(
+            composite_strategy_hash
+        );
+        return (strategies_len, strategies);
+    }
+}

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -50,6 +50,9 @@ func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     register_selector(
         'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
     );
+    register_selector(
+        'assert_can_validate', 0x335791ca04a8d33572330929a1f5d0ed5ccb04474422093c6ca6cb510ad1bc6
+    );
 
     return ();
 }
@@ -134,6 +137,24 @@ func test_can_unassign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
     let test_strategy_hash = TestStrategy.declared();
     with test_strategy_hash {
         let count = TestStrategy.get_function_call_count('assert_can_unassign');
+        assert 3 = count;
+    }
+
+    return ();
+}
+
+@view
+func test_can_validate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let composite_strategy_hash = Composite.default();
+    IAssignmentStrategy.library_call_assert_can_validate(
+        composite_strategy_hash, CONTRIBUTOR_ADDRESS
+    );
+
+    let test_strategy_hash = TestStrategy.declared();
+    with test_strategy_hash {
+        let count = TestStrategy.get_function_call_count('assert_can_validate');
         assert 3 = count;
     }
 

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -47,6 +47,9 @@ func __setup__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     register_selector(
         'assert_can_assign', 0xafebfa3bc187991e56ad073c19677f894a3a5541d8b8151af100e49077f937
     );
+    register_selector(
+        'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
+    );
 
     return ();
 }
@@ -115,6 +118,24 @@ func test_cannot_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
     %{ expect_revert() %}
     let composite_strategy_hash = Composite.default();
     IAssignmentStrategy.assert_can_assign(composite_strategy_hash, CONTRIBUTOR_ADDRESS);
+
+    return ();
+}
+
+@view
+func test_can_unassign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+
+    let composite_strategy_hash = Composite.default();
+    IAssignmentStrategy.library_call_assert_can_unassign(
+        composite_strategy_hash, CONTRIBUTOR_ADDRESS
+    );
+
+    let test_strategy_hash = TestStrategy.declared();
+    with test_strategy_hash {
+        let count = TestStrategy.get_function_call_count('assert_can_unassign');
+        assert 3 = count;
+    }
 
     return ();
 }

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -58,7 +58,7 @@ func test_initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
 @view
 func test_cannot_initialize_twice{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     ) {
-    %{ expect_revert(error_message="Initializable: contract already initialized") %}
+    %{ expect_revert(error_message="Composite: already initialized") %}
     let composite_strategy_hash = Composite.declared();
     with composite_strategy_hash {
         Composite.initialize(0, new ());

--- a/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
+++ b/contracts/onlydust/marketplace/core/assignment_strategies/test_composite.cairo
@@ -84,7 +84,7 @@ func test_can_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
 
 @view
 func test_cannot_assign{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-    AssignmentStrategyMock.request_revert();
+    AssignmentStrategyMock.revert_on_call('assert_can_assign');
 
     %{ expect_revert() %}
     let composite_strategy_hash = Composite.default();

--- a/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
+++ b/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
@@ -2,6 +2,7 @@
 
 from starkware.cairo.common.bool import TRUE, FALSE
 from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_contract_address
 
 @storage_var
 func assignment_strategy__test__function_calls(function_selector: felt) -> (count: felt) {
@@ -33,4 +34,85 @@ func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     }
 
     return (retdata_size=0, retdata=new ());
+}
+
+@contract_interface
+namespace IAssignmentStrategyMock {
+    func request_revert() {
+    }
+}
+
+//
+// AssignmentStrategyMock functions
+//
+namespace AssignmentStrategyMock {
+    func setup{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        alloc_locals;
+
+        %{
+            context.test_strategy_hash = declare("./contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo", config={"wait_for_acceptance": True}).class_hash
+            context.selectors = {}
+        %}
+
+        internal.register_selectors();
+
+        return ();
+    }
+
+    func declared{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+        tempvar test_strategy_hash;
+        %{ ids.test_strategy_hash = context.test_strategy_hash %}
+        return test_strategy_hash;
+    }
+
+    func request_revert{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
+    }() {
+        IAssignmentStrategyMock.library_call_request_revert(test_strategy_hash);
+        return ();
+    }
+
+    func get_function_call_count{
+        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
+    }(function_name) -> felt {
+        alloc_locals;
+        tempvar function_call_count;
+        let (local contract_address) = get_contract_address();
+        %{
+            selector = context.selectors[ids.function_name]
+            storage = load(ids.contract_address, "assignment_strategy__test__function_calls", "felt", key=[selector])
+            ids.function_call_count = storage[0]
+        %}
+        return function_call_count;
+    }
+}
+
+namespace internal {
+    func register_selectors() {
+        register_selector(
+            'assert_can_assign', 0xafebfa3bc187991e56ad073c19677f894a3a5541d8b8151af100e49077f937
+        );
+        register_selector(
+            'on_assigned', 0xf897b8b0d9c032035dd00f05036ece8d0323783ada50f77ac038b5ee28a4f7
+        );
+        register_selector(
+            'assert_can_unassign', 0x24d59f9e6d82d630ed029dc7ad5594e04122af91ac85426ec2c05cfec580997
+        );
+        register_selector(
+            'on_unassigned', 0x85a2edab325660d13eb75ace9a6737467ded8f85473feb457595808fbbfdce
+        );
+        register_selector(
+            'assert_can_validate', 0x335791ca04a8d33572330929a1f5d0ed5ccb04474422093c6ca6cb510ad1bc6
+        );
+        register_selector(
+            'on_validated', 0x8a3674db7fb20b307d4be1223ac3ebe7d05225da47a185d1fffacc26f495c7
+        );
+
+        return ();
+    }
+
+    func register_selector(function_name, selector) {
+        %{ context.selectors[ids.function_name] = ids.selector %}
+        return ();
+    }
 }

--- a/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
+++ b/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
@@ -1,0 +1,35 @@
+%lang starknet
+
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+@storage_var
+func assignment_strategy__test__function_calls(function_selector: felt) -> (count: felt) {
+}
+
+@storage_var
+func assignment_strategy__test__revert_requested() -> (revert_requested: felt) {
+}
+
+@external
+func request_revert{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    assignment_strategy__test__revert_requested.write(TRUE);
+    return ();
+}
+
+@external
+@raw_input
+@raw_output
+func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) -> (retdata_size: felt, retdata: felt*) {
+    let (count) = assignment_strategy__test__function_calls.read(selector);
+    assignment_strategy__test__function_calls.write(selector, count + 1);
+
+    let (revert_requested) = assignment_strategy__test__revert_requested.read();
+    with_attr error_message("Revert requested") {
+        assert FALSE = revert_requested;
+    }
+
+    return (retdata_size=0, retdata=new ());
+}

--- a/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
+++ b/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
@@ -23,6 +23,7 @@ func request_revert{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_
 func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     selector: felt, calldata_size: felt, calldata: felt*
 ) -> (retdata_size: felt, retdata: felt*) {
+    // %{ print(f'{hex(ids.selector)}') %} // Uncomment to add more selectors in unit test
     let (count) = assignment_strategy__test__function_calls.read(selector);
     assignment_strategy__test__function_calls.write(selector, count + 1);
 

--- a/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
+++ b/contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo
@@ -46,35 +46,24 @@ namespace IAssignmentStrategyMock {
 // AssignmentStrategyMock functions
 //
 namespace AssignmentStrategyMock {
-    func setup{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
-        alloc_locals;
-
-        %{
-            context.test_strategy_hash = declare("./contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo", config={"wait_for_acceptance": True}).class_hash
-            context.selectors = {}
-        %}
-
+    func setup{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
         internal.register_selectors();
-
-        return ();
+        return internal.declare();
     }
 
-    func declared{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
-        tempvar test_strategy_hash;
-        %{ ids.test_strategy_hash = context.test_strategy_hash %}
-        return test_strategy_hash;
+    func class_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+        return internal.declare();
     }
 
-    func request_revert{
-        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
-    }() {
+    func request_revert{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let test_strategy_hash = class_hash();
         IAssignmentStrategyMock.library_call_request_revert(test_strategy_hash);
         return ();
     }
 
-    func get_function_call_count{
-        syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, test_strategy_hash
-    }(function_name) -> felt {
+    func get_function_call_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        function_name
+    ) -> felt {
         alloc_locals;
         tempvar function_call_count;
         let (local contract_address) = get_contract_address();
@@ -88,7 +77,20 @@ namespace AssignmentStrategyMock {
 }
 
 namespace internal {
+    func declare{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> felt {
+        tempvar test_strategy_hash;
+        %{
+            if not hasattr(context, 'test_strategy_hash'):
+                context.test_strategy_hash = declare("./contracts/onlydust/marketplace/test/libraries/assignment_strategy_mock.cairo", config={"wait_for_acceptance": True}).class_hash
+            ids.test_strategy_hash = context.test_strategy_hash
+        %}
+
+        return test_strategy_hash;
+    }
+
     func register_selectors() {
+        %{ context.selectors = {} %}
+
         register_selector(
             'assert_can_assign', 0xafebfa3bc187991e56ad073c19677f894a3a5541d8b8151af100e49077f937
         );


### PR DESCRIPTION
- ♻️ rename functions in assignment strategy interface
- ✨ initialize composite stratgegy with array of class hashes
- ✨ prevent double initialization
- ✨ default entry point in composite to forward calls to inner strategies
- 🤡 create an assignment strategy mock
- ✅ test assert_can_assign
- ✅ test assert_can_unassign
- ✅ test assert_can_validate
- ✅ test on_assigned
- ✅ test on_unassigned
- ✅ test on_validated
- 💡 add helper comment in unit test to add more selectors
