### PR TITLE
Prevent adding same lead contributor twice

### DIFF
--- a/contracts/onlydust/marketplace/core/contributions/access_control.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/access_control.cairo
@@ -85,6 +85,11 @@ namespace access_control {
         syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
     }(project_id: felt, lead_contributor_account: felt) {
         only_admin();
+
+        let (is_lead) = is_lead_contributor(project_id, lead_contributor_account); 
+        with_attr error_message("Contributions: Cannot add same lead contributor twice") {
+            assert is_lead = FALSE;
+        }
         has_role_by_project_and_account_.write(
             Role.LEAD_CONTRIBUTOR, project_id, lead_contributor_account, TRUE
         );

--- a/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
+++ b/contracts/onlydust/marketplace/core/contributions/test_contributions_e2e.cairo
@@ -113,7 +113,6 @@ func set_caller_as_lead_contributor{
 func set_caller_as_project_member{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     ) {
     alloc_locals;
-    set_caller_as_lead_contributor();
     let (contributions_contract) = contributions_access.deployed();
 
     %{ stop_prank = start_prank(ids.CALLER_ACCOUNT, ids.contributions_contract) %}


### PR DESCRIPTION
Added a check to prevent adding same lead twice. Also modified tests which were setting it twice and added a specific test for it.